### PR TITLE
Wire public forms to API with client validation and spam checks

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -32,9 +32,10 @@
   <form id="contact-form">
     <div class="form-group"><input type="text" name="name" placeholder="Name" required></div>
     <div class="form-group"><input type="email" name="email" placeholder="Email" required></div>
+    <div class="form-group"><input type="text" name="topic" placeholder="Topic"></div>
     <div class="form-group"><textarea name="message" placeholder="Message" required></textarea></div>
     <button class="btn" type="submit">Send</button>
-    <div class="alert" role="status"></div>
+    <div data-feedback aria-live="polite"></div>
   </form>
   <p>If the form fails, email <a href="mailto:info@example.com">info@example.com</a>.</p>
   <img src="/assets/map.jpg" alt="Map" loading="lazy">
@@ -44,6 +45,7 @@
     <p>&copy; <span id="current-year"></span> Drone Depot</p>
   </div>
 </footer>
+<script>window.API_BASE="__USE_SAME_ORIGIN__";</script>
 <script src="/js/main.js" defer></script>
 </body>
 </html>

--- a/css/components.css
+++ b/css/components.css
@@ -61,3 +61,16 @@ footer {
 footer a {
   color: #fff;
 }
+
+[data-feedback] {
+  display: none;
+  margin-top: var(--spacing-sm);
+}
+[data-feedback].success {
+  color: green;
+  display: block;
+}
+[data-feedback].error {
+  color: red;
+  display: block;
+}

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
 
     <section class="section container" id="lead-intake">
       <h2>Start Your Project</h2>
-      <form id="lead-intake">
+      <form id="lead-intake-form">
         <div class="form-group"><input type="text" name="name" placeholder="Name" required></div>
         <div class="form-group"><input type="email" name="email" placeholder="Email" required></div>
         <div class="form-group"><input type="tel" name="phone" placeholder="Phone"></div>
@@ -93,11 +93,15 @@
           <option>Mapping</option>
         </select></div>
         <div class="form-group"><input type="text" name="address" placeholder="Address" required></div>
-        <div class="form-group"><input type="date" name="date" required></div>
+        <div class="form-group"><input type="text" name="city" placeholder="City"></div>
+        <div class="form-group"><input type="text" name="state" placeholder="State"></div>
+        <div class="form-group"><input type="text" name="postal" placeholder="Postal Code"></div>
+        <div class="form-group"><input type="text" name="country" placeholder="Country"></div>
+        <div class="form-group"><input type="date" name="targetDate"></div>
         <div class="form-group"><textarea name="notes" placeholder="Notes"></textarea></div>
-        <div class="form-group"><label><input type="checkbox" name="remodel"> I need a Remodel Compliance package.</label></div>
+        <div class="form-group"><label><input type="checkbox" name="remodelNeeded"> I need a Remodel Compliance package.</label></div>
         <button class="btn" type="submit">Submit</button>
-        <div class="alert" role="status"></div>
+        <div data-feedback aria-live="polite"></div>
       </form>
     </section>
   </main>
@@ -133,6 +137,7 @@
       <p>&copy; <span id="current-year"></span> Drone Depot</p>
     </div>
   </footer>
+  <script>window.API_BASE="__USE_SAME_ORIGIN__";</script>
   <script src="/js/main.js" defer></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -32,37 +32,166 @@ if (heroVideo) {
   observer.observe(heroVideo);
 }
 
-// Forms handling
-function handleForm(id, endpoint) {
-  const form = document.getElementById(id);
-  if (!form) return;
-  const alertBox = form.querySelector('.alert');
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    alertBox.style.display = 'none';
-    const data = Object.fromEntries(new FormData(form));
-    try {
-      await fetch(endpoint, {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(data)
-      });
-      alertBox.textContent = 'Thanks! We\'ll be in touch.';
-      alertBox.className = 'alert success';
-      alertBox.style.display = 'block';
-      form.reset();
-    } catch (err) {
-      alertBox.textContent = 'Submission failed. Please email us directly.';
-      alertBox.className = 'alert error';
-      alertBox.style.display = 'block';
-    }
+// API helpers and form wiring
+const API_BASE = (window.API_BASE && window.API_BASE !== "__USE_SAME_ORIGIN__") ? window.API_BASE : "";
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_LENGTHS = { name: 120, email: 160, address: 180, notes: 2000 };
+const MIN_SUBMIT_SECONDS = 3;
+
+function postJSON(url, payload) {
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
   });
 }
 
-handleForm('lead-intake', '/api/lead');
-handleForm('remodel-form', '/api/remodel');
-handleForm('municipal-form', '/api/municipal');
-handleForm('contact-form', '/api/contact');
+function postMultipart(url, formEl) {
+  const fd = new FormData(formEl);
+  fd.delete('company');
+  fd.delete('form_started_at');
+  return fetch(url, { method: 'POST', body: fd });
+}
+
+function setFeedback(el, type, message) {
+  if (!el) return;
+  el.textContent = message;
+  el.classList.remove('success', 'error');
+  if (type) el.classList.add(type);
+  el.style.display = message ? 'block' : 'none';
+  if (message) {
+    el.setAttribute('tabindex', '-1');
+    el.focus();
+  }
+}
+
+function applyHoneypot(formEl) {
+  formEl.querySelectorAll('input[name="company"],input[name="form_started_at"]').forEach(el => el.remove());
+  const honey = document.createElement('input');
+  honey.type = 'text';
+  honey.name = 'company';
+  honey.autocomplete = 'off';
+  honey.style.display = 'none';
+  const ts = document.createElement('input');
+  ts.type = 'hidden';
+  ts.name = 'form_started_at';
+  ts.value = Date.now();
+  formEl.append(honey, ts);
+}
+
+function initForms() {
+  const forms = [
+    {
+      selector: '#lead-intake-form',
+      payload: 'json',
+      endpoint: '/api/lead',
+      required: ['name', 'email', 'projectType', 'address'],
+      optional: ['phone', 'city', 'state', 'postal', 'country', 'targetDate', 'notes', 'remodelNeeded'],
+      success: 'Thanks! We\'ll reach out shortly.',
+      error: 'Couldn\'t submit your request. Please try again.'
+    },
+    {
+      selector: '#remodel-form',
+      payload: 'multipart',
+      endpoint: '/api/remodel',
+      required: ['name', 'email', 'address', 'city', 'jurisdiction', 'package'],
+      optional: ['phone', 'permitNumber', 'hoa', 'targetInspectionStart', 'targetInspectionEnd', 'notes'],
+      filesField: 'permitDocs[]',
+      fileRules: { max_files: 10, max_size_bytes: 10485760, accept: /\.(pdf|jpe?g|png)$/i },
+      success: 'Submitted! You\'ll receive a confirmation email with next steps.',
+      error: 'Upload failed. Check file size/types and try again.'
+    },
+    {
+      selector: '#municipal-form',
+      payload: 'json',
+      endpoint: '/api/municipal',
+      required: ['contactName', 'contactEmail', 'department', 'jurisdiction'],
+      optional: ['estMonthlyVolume', 'notes'],
+      success: 'Thanks! We\'ll contact you about the pilot program.',
+      error: 'Couldn\'t send your request. Please try again.'
+    },
+    {
+      selector: '#contact-form',
+      payload: 'json',
+      endpoint: '/api/contact',
+      required: ['name', 'email', 'message'],
+      optional: ['topic'],
+      success: 'Message sent. We\'ll be in touch.',
+      error: 'Couldn\'t send your message. Please try again.'
+    },
+    {
+      selector: '#newsletter-form',
+      payload: 'json',
+      endpoint: '/api/newsletter',
+      required: ['email'],
+      optional: [],
+      success: 'Subscribed! Check your inbox.',
+      error: 'Couldn\'t subscribe. Try again later.'
+    }
+  ];
+
+  forms.forEach(cfg => {
+    const form = document.querySelector(cfg.selector);
+    if (!form) return;
+    applyHoneypot(form);
+    form.addEventListener('submit', async e => {
+      e.preventDefault();
+      const feedbackEl = form.querySelector('[data-feedback]');
+      setFeedback(feedbackEl, '', '');
+      const formData = new FormData(form);
+      if (formData.get('company')) return;
+      const started = parseInt(formData.get('form_started_at'), 10);
+      if (!started || Date.now() - started < MIN_SUBMIT_SECONDS * 1000) {
+        setFeedback(feedbackEl, 'error', cfg.error);
+        return;
+      }
+
+      for (const field of cfg.required) {
+        const value = formData.get(field);
+        if (!value) { setFeedback(feedbackEl, 'error', cfg.error); return; }
+        if (field === 'email' && !EMAIL_REGEX.test(String(value))) { setFeedback(feedbackEl, 'error', cfg.error); return; }
+        const max = MAX_LENGTHS[field];
+        if (max && String(value).length > max) { setFeedback(feedbackEl, 'error', cfg.error); return; }
+      }
+      for (const [field, max] of Object.entries(MAX_LENGTHS)) {
+        const value = formData.get(field);
+        if (value && String(value).length > max) { setFeedback(feedbackEl, 'error', cfg.error); return; }
+      }
+      if (cfg.payload === 'multipart' && cfg.filesField) {
+        const files = formData.getAll(cfg.filesField);
+        if (files.length > cfg.fileRules.max_files) { setFeedback(feedbackEl, 'error', cfg.error); return; }
+        for (const file of files) {
+          if (file.size > cfg.fileRules.max_size_bytes || !cfg.fileRules.accept.test(file.name)) {
+            setFeedback(feedbackEl, 'error', cfg.error);
+            return;
+          }
+        }
+      }
+
+      try {
+        let res;
+        const url = API_BASE + cfg.endpoint;
+        if (cfg.payload === 'multipart') {
+          res = await postMultipart(url, form);
+        } else {
+          formData.delete('company');
+          formData.delete('form_started_at');
+          const payload = {};
+          formData.forEach((v, k) => { payload[k] = v; });
+          res = await postJSON(url, payload);
+        }
+        if (!res.ok) throw new Error('net');
+        setFeedback(feedbackEl, 'success', cfg.success);
+        form.reset();
+        applyHoneypot(form);
+      } catch (err) {
+        setFeedback(feedbackEl, 'error', cfg.error);
+      }
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initForms);
 
 // Analytics helper
 function ddTrack(eventName, payload) {

--- a/municipal.html
+++ b/municipal.html
@@ -39,12 +39,14 @@
   </ol>
   <h2>Request Pilot Program</h2>
   <form id="municipal-form">
+    <div class="form-group"><input type="text" name="contactName" placeholder="Contact Name" required></div>
+    <div class="form-group"><input type="email" name="contactEmail" placeholder="Contact Email" required></div>
     <div class="form-group"><input type="text" name="department" placeholder="Department" required></div>
     <div class="form-group"><input type="text" name="jurisdiction" placeholder="Jurisdiction" required></div>
-    <div class="form-group"><input type="text" name="contact" placeholder="Contact" required></div>
-    <div class="form-group"><input type="number" name="volume" placeholder="Monthly volume" required></div>
+    <div class="form-group"><input type="number" name="estMonthlyVolume" placeholder="Est. Monthly Volume"></div>
+    <div class="form-group"><textarea name="notes" placeholder="Notes"></textarea></div>
     <button class="btn" type="submit">Submit</button>
-    <div class="alert" role="status"></div>
+    <div data-feedback aria-live="polite"></div>
   </form>
 </main>
 <footer>
@@ -59,6 +61,7 @@
     document.getElementById('city-badge').textContent = `- Official Pilot City: ${city}`;
   }
 </script>
+<script>window.API_BASE="__USE_SAME_ORIGIN__";</script>
 <script src="/js/main.js" defer></script>
 </body>
 </html>

--- a/remodel.html
+++ b/remodel.html
@@ -61,19 +61,22 @@
   </section>
   <section class="section container">
     <h2>Start Remodel Package</h2>
-    <form id="remodel-form">
+    <form id="remodel-form" enctype="multipart/form-data">
       <div class="form-group"><input type="text" name="name" placeholder="Name" required></div>
       <div class="form-group"><input type="email" name="email" placeholder="Email" required></div>
-      <div class="form-group"><input type="tel" name="phone" placeholder="Phone" required></div>
+      <div class="form-group"><input type="tel" name="phone" placeholder="Phone"></div>
       <div class="form-group"><input type="text" name="address" placeholder="Address" required></div>
-      <div class="form-group"><input type="text" name="city" placeholder="City/Jurisdiction" required></div>
-      <div class="form-group"><input type="text" name="permit" placeholder="Permit #"></div>
-      <div class="form-group"><select name="hoa" required><option value="">HOA?</option><option>Yes</option><option>No</option></select></div>
-      <div class="form-group"><input type="text" name="dates" placeholder="Target inspection dates"></div>
+      <div class="form-group"><input type="text" name="city" placeholder="City" required></div>
+      <div class="form-group"><input type="text" name="jurisdiction" placeholder="Jurisdiction" required></div>
+      <div class="form-group"><select name="package" required><option value="">Package</option><option>Starter</option><option>Standard</option><option>Pro</option></select></div>
+      <div class="form-group"><input type="text" name="permitNumber" placeholder="Permit #"></div>
+      <div class="form-group"><select name="hoa"><option value="">HOA?</option><option>Yes</option><option>No</option></select></div>
+      <div class="form-group"><input type="date" name="targetInspectionStart" placeholder="Inspection start"></div>
+      <div class="form-group"><input type="date" name="targetInspectionEnd" placeholder="Inspection end"></div>
       <div class="form-group"><textarea name="notes" placeholder="Notes"></textarea></div>
-      <div class="form-group"><input type="file" name="permitFile" accept="application/pdf"></div>
+      <div class="form-group"><input type="file" name="permitDocs[]" accept=".pdf,.jpg,.jpeg,.png" multiple></div>
       <button class="btn" type="submit">Submit</button>
-      <div class="alert" role="status"></div>
+      <div data-feedback aria-live="polite"></div>
     </form>
   </section>
 </main>
@@ -82,6 +85,7 @@
     <p>&copy; <span id="current-year"></span> Drone Depot</p>
   </div>
 </footer>
+<script>window.API_BASE="__USE_SAME_ORIGIN__";</script>
 <script src="/js/main.js" defer></script>
 </body>
 </html>

--- a/resources.html
+++ b/resources.html
@@ -37,10 +37,10 @@
   <div id="guide-modal" class="modal">
     <div class="modal-content">
       <h2>Smart Buyer’s Guide</h2>
-      <form id="guide-form">
+      <form id="newsletter-form">
         <div class="form-group"><input type="email" name="email" placeholder="Email" required></div>
         <button class="btn" type="submit">Get Guide</button>
-        <div class="alert" role="status"></div>
+        <div data-feedback aria-live="polite"></div>
       </form>
     </div>
   </div>
@@ -57,6 +57,7 @@
   modal.addEventListener('click',e=>{if(e.target===modal)modal.style.display='none';});
   document.addEventListener('DOMContentLoaded',()=>{if(window.location.hash==='#guide')modal.style.display='flex';});
 </script>
+<script>window.API_BASE="__USE_SAME_ORIGIN__";</script>
 <script src="/js/main.js" defer></script>
 </body>
 </html>

--- a/services.html
+++ b/services.html
@@ -43,6 +43,7 @@
       <p>&copy; <span id="current-year"></span> Drone Depot</p>
     </div>
   </footer>
+  <script>window.API_BASE="__USE_SAME_ORIGIN__";</script>
   <script src="/js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Wire lead, remodel, municipal, contact and newsletter forms to live `/api/*` endpoints.
- Add client-side validation, honeypot & timestamp anti-spam, and accessible feedback messaging.
- Style feedback states and expose `API_BASE` for configurable API routing.

## Testing
- `npm test` *(fails: FAIL tests/api.test.js > Public API v1 > Rate Limiting > should apply rate limiting to job requests)*

------
https://chatgpt.com/codex/tasks/task_e_689b865d9f6c832d95c4867b87d20f8c