### PR TITLE
test: add Playwright tests and CI workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,28 @@
+name: Playwright Tests
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - name: Run Playwright
+        env:
+          NEXT_PUBLIC_DRONEREGION_URL: ${{ secrets.NEXT_PUBLIC_DRONEREGION_URL }}
+        run: npx playwright test
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/frontend/playwright-report

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -2,24 +2,21 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests",
-  webServer: {
-    command: "npm run dev",
-    port: 3000,
-    reuseExistingServer: !process.env.CI,
-    env: {
-      NEXT_PUBLIC_API_BASE_URL: "http://localhost:3000",
-      NEXT_PUBLIC_DRONEREGION_URL: "https://example.com",
-      NEXT_PUBLIC_SITE_URL: "http://localhost:3000",
-    },
-  },
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000",
+    viewport: { width: 1280, height: 720 },
+    colorScheme: "light",
     trace: "on-first-retry",
   },
   projects: [
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
-    },
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    { name: "firefox", use: { ...devices["Desktop Firefox"] } },
+    { name: "webkit", use: { ...devices["Desktop Safari"] } },
   ],
+  webServer: {
+    command: process.env.PLAYWRIGHT_DEV_COMMAND || "npm run dev",
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+    env: { NEXT_PUBLIC_DRONEREGION_URL: process.env.NEXT_PUBLIC_DRONEREGION_URL },
+  },
 });

--- a/apps/frontend/tests/buyers-guide-redirect.spec.ts
+++ b/apps/frontend/tests/buyers-guide-redirect.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "@playwright/test";
+
+const dr = process.env.NEXT_PUBLIC_DRONEREGION_URL!;
+
+test("redirects to DroneRegion with UTMs preserved", async ({ request }) => {
+  const res = await request.get("/buyers-guide?utm_source=test&utm_medium=ad", {
+    maxRedirects: 0,
+  });
+  expect([307, 308]).toContain(res.status());
+  expect(res.headers()["location"]).toBe(
+    `${dr}/buyers-guide?utm_source=test&utm_medium=ad`
+  );
+});
+
+test("nav link appends current UTMs", async ({ page }) => {
+  await page.goto("/?utm_source=test&utm_medium=ad");
+  const link = page.getByRole("link", { name: "Buyer’s Guide" });
+  await expect(link).toHaveAttribute(
+    "href",
+    `${dr}/buyers-guide?utm_source=test&utm_medium=ad`
+  );
+});

--- a/apps/frontend/tests/buyersguide.spec.ts
+++ b/apps/frontend/tests/buyersguide.spec.ts
@@ -1,8 +1,0 @@
-import { test, expect } from "@playwright/test";
-
-test("buyers guide redirect", async ({ page }) => {
-  await page.route("https://example.com/*", (route) => route.fulfill({ status: 200, body: "ok" }));
-  const res = await page.goto("/buyers-guide?utm_source=test");
-  expect(res?.status()).toBe(200);
-  expect(page.url()).toBe("https://example.com/buyers-guide");
-});

--- a/apps/frontend/tests/lazy-reduced.spec.ts
+++ b/apps/frontend/tests/lazy-reduced.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect, type Locator } from "@playwright/test";
+
+async function getOpacity(el: Locator) {
+  return el.evaluate((e) => parseFloat(getComputedStyle(e).opacity));
+}
+
+test("lazy-loads video sources only after intersection", async ({ page }) => {
+  await page.goto("/");
+  const sections = page.locator("main section");
+  const second = sections.nth(1).locator('[data-testid="video-wrapper"]');
+
+  await expect(second.locator("source")).toHaveCount(0);
+
+  const [req] = await Promise.all([
+    page.waitForRequest(/hero\.mp4$/),
+    second.scrollIntoViewIfNeeded(),
+  ]);
+
+  await expect(second.locator("source")).toHaveCount(1);
+  expect(req.url()).toMatch(/hero\.mp4$/);
+});
+
+test("respects prefers-reduced-motion (no autoplay, CTA visible)", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/");
+
+  const video = page.locator('[data-testid="video-wrapper"] video').first();
+  await page.waitForTimeout(500);
+  const time = await video.evaluate((v) => (v as HTMLVideoElement).currentTime);
+  expect(time).toBeLessThan(0.2);
+
+  const cta = page.locator('[data-testid="cta-panel"]').first();
+  expect(await getOpacity(cta)).toBeGreaterThan(0.9);
+});

--- a/apps/frontend/tests/scroll-cinema.spec.ts
+++ b/apps/frontend/tests/scroll-cinema.spec.ts
@@ -1,29 +1,58 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Locator } from "@playwright/test";
 
-test("lazy-loads videos on intersection", async ({ page }) => {
+async function getOpacity(el: Locator) {
+  return el.evaluate((e) => parseFloat(getComputedStyle(e).opacity));
+}
+
+async function sectionScroll(section: Locator, ratio: number) {
+  await section.evaluate((el, r) => {
+    const rect = el.getBoundingClientRect();
+    window.scrollTo(0, window.scrollY + rect.top + rect.height * r);
+  }, ratio);
+  await section.page().waitForTimeout(50);
+}
+
+test("videos are full-bleed, sticky, and CTA fades", async ({ page }) => {
   await page.goto("/");
-  const wrappers = page.locator("[data-testid='video-wrapper']");
-  await expect(wrappers.nth(1).locator("source")).toHaveCount(0);
-  await wrappers.nth(1).scrollIntoViewIfNeeded();
-  await expect(wrappers.nth(1).locator("source")).toHaveCount(1);
+  const sections = page.locator("main section");
+  expect(await sections.count()).toBe(3);
+
+  for (let i = 0; i < 3; i++) {
+    const section = sections.nth(i);
+    const wrapper = section.locator('[data-testid="video-wrapper"]');
+    const cta = section.locator('[data-testid="cta-panel"]');
+
+    await sectionScroll(section, 0.05);
+    const box = await wrapper.boundingBox();
+    const vp = page.viewportSize();
+    if (!box || !vp) throw new Error("bounding boxes not found");
+    expect(Math.abs(box.width - vp.width)).toBeLessThanOrEqual(1);
+    expect(Math.abs(box.height - vp.height)).toBeLessThanOrEqual(1);
+
+    const topStart = await wrapper.evaluate((e) => e.getBoundingClientRect().top);
+    await sectionScroll(section, 0.6);
+    const topMid = await wrapper.evaluate((e) => e.getBoundingClientRect().top);
+    expect(Math.abs(topStart - topMid)).toBeLessThanOrEqual(8);
+
+    await sectionScroll(section, 0.1);
+    expect(await getOpacity(cta)).toBeLessThan(0.15);
+    await sectionScroll(section, 0.3);
+    expect(await getOpacity(cta)).toBeGreaterThan(0.75);
+    await sectionScroll(section, 0.9);
+    expect(await getOpacity(cta)).toBeLessThan(0.15);
+  }
 });
 
-test("shows poster and no autoplay when reduced motion", async ({ page }) => {
-  await page.emulateMedia({ reducedMotion: "reduce" });
-  await page.goto("/");
-  const first = page.locator("[data-testid='video-wrapper']").first();
-  await expect(first.getByRole("button", { name: "Tap to play" })).toBeVisible();
-});
-
-test("mobile layout stacks video and CTA", async ({ page }) => {
+test("mobile layout stacks CTA below video and keeps it visible", async ({ page }) => {
   await page.setViewportSize({ width: 375, height: 812 });
   await page.goto("/");
-  const section = page.locator("section").first();
-  const videoBox = await section.locator("[data-testid='video-wrapper']").boundingBox();
-  const ctaBox = await section.locator("[data-testid='cta-panel']").boundingBox();
-  if (videoBox && ctaBox) {
-    expect(ctaBox.y).toBeGreaterThanOrEqual(videoBox.y + videoBox.height);
-  } else {
-    throw new Error("bounding boxes not found");
-  }
+
+  const section = page.locator("main section").first();
+  const videoBox = await section.locator('[data-testid="video-wrapper"]').boundingBox();
+  const cta = section.locator('[data-testid="cta-panel"]');
+  const ctaBox = await cta.boundingBox();
+  if (!videoBox || !ctaBox) throw new Error("bounding boxes not found");
+
+  expect(ctaBox.y).toBeGreaterThanOrEqual(videoBox.y + videoBox.height);
+  expect(await getOpacity(cta)).toBeGreaterThan(0.9);
 });


### PR DESCRIPTION
## Summary
- add Playwright config with baseURL, 3 browsers and dev server setup
- add tests for video lazy-loading, reduced motion, sticky CTA, and redirect UTMs
- run Playwright in CI via GitHub Actions

## Testing
- `npm ci`
- `npx playwright install --with-deps` *(fails: Domain forbidden)*
- `npx playwright test` *(fails: missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_689bfb1fbd8c832da6e4054585853916