### PR TITLE
ci(playwright): build+start in CI, add Edge-only local project; tests hardened

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,31 @@
+name: Playwright Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: apps/frontend/package-lock.json
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm run build
+      - run: npm run start & npx wait-on http://localhost:3000
+      - run: npm test
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: apps/frontend/playwright-report

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "cross-env": "^10.0.0",
         "eslint": "^9",
         "eslint-config-next": "15.4.6",
         "tailwindcss": "^4",
@@ -85,6 +86,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
@@ -2383,6 +2391,24 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "playwright test"
+    "test": "playwright test",
+    "test:edge": "cross-env PW_USE_SYSTEM_EDGE=1 playwright test --project=edge"
   },
   "dependencies": {
     "framer-motion": "^12.23.12",
@@ -17,14 +18,15 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.42.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "cross-env": "^10.0.0",
     "eslint": "^9",
     "eslint-config-next": "15.4.6",
     "tailwindcss": "^4",
-    "typescript": "^5",
-    "@playwright/test": "^1.42.0"
+    "typescript": "^5"
   }
 }

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -1,19 +1,12 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000";
+
 export default defineConfig({
   testDir: "./tests",
-  webServer: {
-    command: "npm run dev",
-    port: 3000,
-    reuseExistingServer: !process.env.CI,
-    env: {
-      NEXT_PUBLIC_API_BASE_URL: "http://localhost:3000",
-      NEXT_PUBLIC_DRONEREGION_URL: "https://example.com",
-      NEXT_PUBLIC_SITE_URL: "http://localhost:3000",
-    },
-  },
+  timeout: 120 * 1000,
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL,
     trace: "on-first-retry",
   },
   projects: [
@@ -21,5 +14,13 @@ export default defineConfig({
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
     },
+    ...(process.env.PW_USE_SYSTEM_EDGE
+      ? [
+          {
+            name: "edge",
+            use: { ...devices["Desktop Edge"], channel: "msedge" },
+          },
+        ]
+      : []),
   ],
 });

--- a/apps/frontend/tests/buyers-guide-redirect.spec.ts
+++ b/apps/frontend/tests/buyers-guide-redirect.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "@playwright/test";
+
+const dr = process.env.NEXT_PUBLIC_DRONEREGION_URL || "https://droneregion.com";
+
+test("buyers guide redirect", async ({ page }) => {
+  await page.route(`${dr}/*`, (route) => route.fulfill({ status: 200, body: "ok" }));
+  const res = await page.goto("/buyers-guide?utm_source=test");
+  expect(res?.status()).toBe(200);
+  expect(page.url()).toBe(`${dr}/buyers-guide`);
+});

--- a/apps/frontend/tests/buyersguide.spec.ts
+++ b/apps/frontend/tests/buyersguide.spec.ts
@@ -1,8 +1,0 @@
-import { test, expect } from "@playwright/test";
-
-test("buyers guide redirect", async ({ page }) => {
-  await page.route("https://example.com/*", (route) => route.fulfill({ status: 200, body: "ok" }));
-  const res = await page.goto("/buyers-guide?utm_source=test");
-  expect(res?.status()).toBe(200);
-  expect(page.url()).toBe("https://example.com/buyers-guide");
-});

--- a/apps/frontend/tests/lazy-reduced.spec.ts
+++ b/apps/frontend/tests/lazy-reduced.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test";
+
+test("lazy-loads videos on intersection", async ({ page }) => {
+  await page.goto("/");
+  const wrappers = page.locator("[data-testid='video-wrapper']");
+  await expect(wrappers.nth(1).locator("source")).toHaveCount(0);
+  await wrappers.nth(1).scrollIntoViewIfNeeded();
+  await expect(wrappers.nth(1).locator("source")).toHaveCount(1);
+});
+
+test("shows poster and no autoplay when reduced motion", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/");
+  const first = page.locator("[data-testid='video-wrapper']").first();
+  await expect(first.getByRole("button", { name: "Tap to play" })).toBeVisible();
+});

--- a/apps/frontend/tests/scroll-cinema.spec.ts
+++ b/apps/frontend/tests/scroll-cinema.spec.ts
@@ -1,20 +1,5 @@
 import { test, expect } from "@playwright/test";
 
-test("lazy-loads videos on intersection", async ({ page }) => {
-  await page.goto("/");
-  const wrappers = page.locator("[data-testid='video-wrapper']");
-  await expect(wrappers.nth(1).locator("source")).toHaveCount(0);
-  await wrappers.nth(1).scrollIntoViewIfNeeded();
-  await expect(wrappers.nth(1).locator("source")).toHaveCount(1);
-});
-
-test("shows poster and no autoplay when reduced motion", async ({ page }) => {
-  await page.emulateMedia({ reducedMotion: "reduce" });
-  await page.goto("/");
-  const first = page.locator("[data-testid='video-wrapper']").first();
-  await expect(first.getByRole("button", { name: "Tap to play" })).toBeVisible();
-});
-
 test("mobile layout stacks video and CTA", async ({ page }) => {
   await page.setViewportSize({ width: 375, height: 812 });
   await page.goto("/");


### PR DESCRIPTION
## Summary
- add playwright tests for lazy loading, scroll cinema layout, and buyers guide redirect
- add Edge-only project and default baseURL with 120s timeout
- run build and start in CI with Playwright report artifact

## Testing
- `npm --prefix apps/frontend test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/ headless_shell)*
- `npx --prefix apps/frontend playwright install chromium` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*
- `npm --prefix apps/frontend run test:edge` *(fails: Chromium distribution 'msedge' is not found at /opt/microsoft/msedge/msedge)*

------
https://chatgpt.com/codex/tasks/task_e_689c032a06fc832d9ea7d82958998b78