### PR TITLE
fix: absolute CSS/JS paths + cache busting

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Page Not Found | Drone Depot</title>
-  <link rel="stylesheet" href="/css/base.css">
-  <link rel="stylesheet" href="/css/components.css">
-  <link rel="stylesheet" href="/css/layout.css">
+  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
 </head>
 <body>
 <header>
@@ -36,6 +36,6 @@
   </div>
 </footer>
 <script>window.API_BASE="__USE_SAME_ORIGIN__";</script>
-<script src="/js/main.js" defer></script>
+<script src="/js/main.js?cb=1756180468" defer></script>
 </body>
 </html>

--- a/500.html
+++ b/500.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Server Error | Drone Depot</title>
-  <link rel="stylesheet" href="/css/base.css">
-  <link rel="stylesheet" href="/css/components.css">
-  <link rel="stylesheet" href="/css/layout.css">
+  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
 </head>
 <body>
 <header>
@@ -36,6 +36,6 @@
   </div>
 </footer>
 <script>window.API_BASE="__USE_SAME_ORIGIN__";</script>
-<script src="/js/main.js" defer></script>
+<script src="/js/main.js?cb=1756180468" defer></script>
 </body>
 </html>

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+fix-paths:
+	./scripts/fix_asset_paths.sh
+
+bust-cache:
+	./scripts/bump_cache_token.sh

--- a/README.md
+++ b/README.md
@@ -31,3 +31,25 @@ npm start
 
 ## License
 MIT
+
+## Asset paths & cache busting
+Run these before deploys:
+
+    make fix-paths
+    make bust-cache
+
+This forces absolute /css and /js URLs and bumps a ?cb=<timestamp> query so CDNs/browsers pull fresh files.
+
+## VPS sanity check (Hostinger, Nginx)
+Docroot should be: ~/domains/drone-depot.ai/public_html
+
+On the VPS:
+    curl -I https://drone-depot.ai/css/base.css  # expect 200 and content-type: text/css
+
+If content-type is not text/css, in /etc/nginx/nginx.conf ensure:
+    include /etc/nginx/mime.types;
+
+Reload:
+    nginx -t && systemctl reload nginx
+
+Purge Hostinger cache (hPanel > Cache Manager), then hard-refresh the browser.

--- a/about.html
+++ b/about.html
@@ -13,10 +13,10 @@
   <meta name="twitter:title" content="About Drone Depot">
   <meta name="twitter:description" content="Mission, vetting standards, safety & compliance.">
   <meta name="twitter:image" content="/assets/og-hero.jpg">
-  <link rel="stylesheet" href="/css/base.css">
-  <link rel="stylesheet" href="/css/components.css">
-  <link rel="stylesheet" href="/css/layout.css">
-  <link rel="stylesheet" href="/css/pages.css">
+  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/pages.css?cb=1756180468">
 </head>
 <body>
 <header>
@@ -46,6 +46,6 @@
   </footer>
   <div class="analytics-consent"><label><input type="checkbox" data-consent-toggle> Allow analytics</label></div>
   <script>window.DD_ANALYTICS=false;window.DD_GA_ID='G-XXXXXXXXXX';</script>
-<script src="/js/main.js" defer></script>
+<script src="/js/main.js?cb=1756180468" defer></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -13,10 +13,10 @@
   <meta name="twitter:title" content="Contact — Book a Free Consultation">
   <meta name="twitter:description" content="Talk to a specialist and get matched quickly.">
   <meta name="twitter:image" content="/assets/og-hero.jpg">
-  <link rel="stylesheet" href="/css/base.css">
-  <link rel="stylesheet" href="/css/components.css">
-  <link rel="stylesheet" href="/css/layout.css">
-  <link rel="stylesheet" href="/css/pages.css">
+  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/pages.css?cb=1756180468">
 </head>
 <body>
 <header>
@@ -56,6 +56,6 @@
 <div class="analytics-consent"><label><input type="checkbox" data-consent-toggle> Allow analytics</label></div>
 <script>window.DD_ANALYTICS=false;window.DD_GA_ID='G-XXXXXXXXXX';</script>
 <script>window.API_BASE="__USE_SAME_ORIGIN__";</script>
-<script src="/js/main.js" defer></script>
+<script src="/js/main.js?cb=1756180468" defer></script>
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -13,10 +13,10 @@
   <meta name="twitter:title" content="FAQ — Drones, Compliance & Deliverables">
   <meta name="twitter:description" content="Legality, insurance, night flights, formats, timelines, reschedules, privacy.">
   <meta name="twitter:image" content="/assets/og-hero.jpg">
-  <link rel="stylesheet" href="/css/base.css">
-  <link rel="stylesheet" href="/css/components.css">
-  <link rel="stylesheet" href="/css/layout.css">
-  <link rel="stylesheet" href="/css/pages.css">
+  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/pages.css?cb=1756180468">
   <script type="application/ld+json">
   {
     "@context":"https://schema.org",
@@ -73,6 +73,6 @@
 </footer>
 <div class="analytics-consent"><label><input type="checkbox" data-consent-toggle> Allow analytics</label></div>
 <script>window.DD_ANALYTICS=false;window.DD_GA_ID='G-XXXXXXXXXX';</script>
-<script src="/js/main.js" defer></script>
+<script src="/js/main.js?cb=1756180468" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -22,10 +22,10 @@
     .hero video{position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;z-index:-1;background:#000;}
     .hero .content{z-index:1;padding:0 1rem;}
   </style>
-  <link rel="stylesheet" href="css/base.css?v=1.0.1">
-  <link rel="stylesheet" href="css/components.css?v=1.0.1">
-  <link rel="stylesheet" href="css/layout.css?v=1.0.1">
-  <link rel="stylesheet" href="css/pages.css?v=1.0.1">
+  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/pages.css?cb=1756180468">
 </head>
 <body>
   <header>
@@ -217,7 +217,7 @@
   <div class="analytics-consent"><label><input type="checkbox" data-consent-toggle> Allow analytics</label></div>
   <script>window.DD_ANALYTICS=false;window.DD_GA_ID='G-XXXXXXXXXX';</script>
   <script>window.API_BASE="__USE_SAME_ORIGIN__";</script>
-  <script src="js/scroll-cinema.js?v=1.0.1" defer></script>
-  <script src="js/main.js?v=1.0.1" defer></script>
+  <script src="/js/scroll-cinema.js?cb=1756180468" defer></script>
+  <script src="/js/main.js?cb=1756180468" defer></script>
 </body>
 </html>

--- a/legal/privacy.html
+++ b/legal/privacy.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Privacy Policy | Drone Depot</title>
-  <link rel="stylesheet" href="/css/base.css">
-  <link rel="stylesheet" href="/css/components.css">
-  <link rel="stylesheet" href="/css/layout.css">
-  <link rel="stylesheet" href="/css/pages.css">
+  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/pages.css?cb=1756180468">
 </head>
 <body>
 <main class="container">
@@ -15,6 +15,6 @@
   <p>Last updated <span id="current-year"></span>.</p>
   <p>Your privacy is important to us.</p>
 </main>
-<script src="/js/main.js" defer></script>
+<script src="/js/main.js?cb=1756180468" defer></script>
 </body>
 </html>

--- a/legal/terms.html
+++ b/legal/terms.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Terms of Service | Drone Depot</title>
-  <link rel="stylesheet" href="/css/base.css">
-  <link rel="stylesheet" href="/css/components.css">
-  <link rel="stylesheet" href="/css/layout.css">
-  <link rel="stylesheet" href="/css/pages.css">
+  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/pages.css?cb=1756180468">
 </head>
 <body>
 <main class="container">
@@ -15,6 +15,6 @@
   <p>Effective <span id="current-year"></span>.</p>
   <p>Use of this site constitutes acceptance of these terms.</p>
 </main>
-<script src="/js/main.js" defer></script>
+<script src="/js/main.js?cb=1756180468" defer></script>
 </body>
 </html>

--- a/municipal.html
+++ b/municipal.html
@@ -13,10 +13,10 @@
   <meta name="twitter:title" content="Municipal Partner Portal (Beta)">
   <meta name="twitter:description" content="Resident-friendly documentation path, consistent submissions, faster approvals.">
   <meta name="twitter:image" content="/assets/og-hero.jpg">
-  <link rel="stylesheet" href="/css/base.css">
-  <link rel="stylesheet" href="/css/components.css">
-  <link rel="stylesheet" href="/css/layout.css">
-  <link rel="stylesheet" href="/css/pages.css">
+  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/pages.css?cb=1756180468">
 </head>
 <body>
 <header>
@@ -65,6 +65,6 @@
   <div class="analytics-consent"><label><input type="checkbox" data-consent-toggle> Allow analytics</label></div>
   <script>window.DD_ANALYTICS=false;window.DD_GA_ID='G-XXXXXXXXXX';</script>
   <script>window.API_BASE="__USE_SAME_ORIGIN__";</script>
-<script src="/js/main.js" defer></script>
+<script src="/js/main.js?cb=1756180468" defer></script>
 </body>
 </html>

--- a/remodel.html
+++ b/remodel.html
@@ -13,10 +13,10 @@
   <meta name="twitter:title" content="Residential Remodel Compliance — Photo/Video/Report">
   <meta name="twitter:description" content="Standardized documentation packages aligned to local submittals.">
   <meta name="twitter:image" content="/assets/og-hero.jpg">
-  <link rel="stylesheet" href="/css/base.css">
-  <link rel="stylesheet" href="/css/components.css">
-  <link rel="stylesheet" href="/css/layout.css">
-  <link rel="stylesheet" href="/css/pages.css">
+  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/pages.css?cb=1756180468">
 </head>
 <body>
 <header>
@@ -99,6 +99,6 @@
   <div class="analytics-consent"><label><input type="checkbox" data-consent-toggle> Allow analytics</label></div>
   <script>window.DD_ANALYTICS=false;window.DD_GA_ID='G-XXXXXXXXXX';</script>
   <script>window.API_BASE="__USE_SAME_ORIGIN__";</script>
-  <script src="/js/main.js" defer></script>
+  <script src="/js/main.js?cb=1756180468" defer></script>
 </body>
 </html>

--- a/scripts/bump_cache_token.sh
+++ b/scripts/bump_cache_token.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s globstar
+
+CB="$(date +%s)"
+for f in **/*.html; do
+  [[ -f "$f" ]] || continue
+  # Add or replace ?cb= on CSS refs
+  sed -i -E 's@(href="/css/[^"?]+)(\?cb=[0-9]+)?@\1?cb='"$CB"'@g' "$f"
+  # Add or replace ?cb= on JS refs
+  sed -i -E 's@(src="/js/[^"?]+)(\?cb=[0-9]+)?@\1?cb='"$CB"'@g' "$f"
+done
+echo "Cache token set to $CB"

--- a/scripts/fix_asset_paths.sh
+++ b/scripts/fix_asset_paths.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s globstar
+
+changed=0
+for f in **/*.html; do
+  [[ -f "$f" ]] || continue
+  # Make paths absolute from docroot
+  sed -i -E 's@href="css/@href="/css/@g; s@src="js/@src="/js/@g' "$f" && changed=1
+done
+
+if [[ $changed -eq 1 ]]; then
+  echo "Asset paths normalized to /css and /js."
+else
+  echo "No HTML files changed."
+fi

--- a/services.html
+++ b/services.html
@@ -13,10 +13,10 @@
   <meta name="twitter:title" content="Services — Aerial Photo/Video, Mapping, Events">
   <meta name="twitter:description" content="Transparent deliverables, fast turnaround, and insured operators.">
   <meta name="twitter:image" content="/assets/og-hero.jpg">
-  <link rel="stylesheet" href="/css/base.css">
-  <link rel="stylesheet" href="/css/components.css">
-  <link rel="stylesheet" href="/css/layout.css">
-  <link rel="stylesheet" href="/css/pages.css">
+  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/pages.css?cb=1756180468">
 </head>
 <body>
   <header>
@@ -54,6 +54,6 @@
   <div class="analytics-consent"><label><input type="checkbox" data-consent-toggle> Allow analytics</label></div>
   <script>window.DD_ANALYTICS=false;window.DD_GA_ID='G-XXXXXXXXXX';</script>
   <script>window.API_BASE="__USE_SAME_ORIGIN__";</script>
-  <script src="/js/main.js" defer></script>
+  <script src="/js/main.js?cb=1756180468" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add fix_asset_paths and bump_cache_token scripts to enforce absolute /css and /js paths with a cache-busting token
- document cache busting workflow and VPS sanity check
- include Makefile helpers for path normalization and cache busting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad2ed48d94832d9774343cf18262a5