### PR TITLE
chore: standardize stylesheet loading

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,9 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Page Not Found | Drone Depot</title>
-  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/base.css">
+  <link rel="stylesheet" href="/css/components.css">
+  <link rel="stylesheet" href="/css/layout.css">
+  <link rel="stylesheet" href="/css/pages.css">
 </head>
 <body>
 <header>

--- a/500.html
+++ b/500.html
@@ -4,9 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Server Error | Drone Depot</title>
-  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/base.css">
+  <link rel="stylesheet" href="/css/components.css">
+  <link rel="stylesheet" href="/css/layout.css">
+  <link rel="stylesheet" href="/css/pages.css">
 </head>
 <body>
 <header>

--- a/about.html
+++ b/about.html
@@ -13,10 +13,10 @@
   <meta name="twitter:title" content="About Drone Depot">
   <meta name="twitter:description" content="Mission, vetting standards, safety & compliance.">
   <meta name="twitter:image" content="/assets/og-hero.jpg">
-  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/pages.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/base.css">
+  <link rel="stylesheet" href="/css/components.css">
+  <link rel="stylesheet" href="/css/layout.css">
+  <link rel="stylesheet" href="/css/pages.css">
 </head>
 <body>
 <header>

--- a/contact.html
+++ b/contact.html
@@ -13,10 +13,10 @@
   <meta name="twitter:title" content="Contact — Book a Free Consultation">
   <meta name="twitter:description" content="Talk to a specialist and get matched quickly.">
   <meta name="twitter:image" content="/assets/og-hero.jpg">
-  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/pages.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/base.css">
+  <link rel="stylesheet" href="/css/components.css">
+  <link rel="stylesheet" href="/css/layout.css">
+  <link rel="stylesheet" href="/css/pages.css">
 </head>
 <body>
 <header>

--- a/faq.html
+++ b/faq.html
@@ -13,10 +13,10 @@
   <meta name="twitter:title" content="FAQ — Drones, Compliance & Deliverables">
   <meta name="twitter:description" content="Legality, insurance, night flights, formats, timelines, reschedules, privacy.">
   <meta name="twitter:image" content="/assets/og-hero.jpg">
-  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/pages.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/base.css">
+  <link rel="stylesheet" href="/css/components.css">
+  <link rel="stylesheet" href="/css/layout.css">
+  <link rel="stylesheet" href="/css/pages.css">
   <script type="application/ld+json">
   {
     "@context":"https://schema.org",

--- a/index.html
+++ b/index.html
@@ -13,19 +13,10 @@
   <meta name="twitter:title" content="Drone Depot — Hire Vetted Drone Pros Fast">
   <meta name="twitter:description" content="On-demand aerial photos, video & data. Residential Remodel Compliance packages and municipal pilot support.">
   <meta name="twitter:image" content="/assets/og-hero.jpg">
-  <style id="critical-css-inline">
-    body{margin:0;font-family:'Helvetica Neue',Arial,sans-serif;color:#1a1a1a;background:#fff;}
-    header{background:#fff;}
-    .navbar{display:flex;justify-content:space-between;align-items:center;padding:1rem;}
-    .navbar-toggle{background:none;border:0;font-size:1.5rem;}
-    .hero{position:relative;height:60vh;display:flex;align-items:center;justify-content:center;color:#fff;text-align:center;}
-    .hero video{position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;z-index:-1;background:#000;}
-    .hero .content{z-index:1;padding:0 1rem;}
-  </style>
-  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/pages.css?cb=1756180468">
+    <link rel="stylesheet" href="/css/base.css">
+  <link rel="stylesheet" href="/css/components.css">
+  <link rel="stylesheet" href="/css/layout.css">
+  <link rel="stylesheet" href="/css/pages.css">
 </head>
 <body>
   <header>

--- a/legal/privacy.html
+++ b/legal/privacy.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Privacy Policy | Drone Depot</title>
-  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/pages.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/base.css">
+  <link rel="stylesheet" href="/css/components.css">
+  <link rel="stylesheet" href="/css/layout.css">
+  <link rel="stylesheet" href="/css/pages.css">
 </head>
 <body>
 <main class="container">

--- a/legal/terms.html
+++ b/legal/terms.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Terms of Service | Drone Depot</title>
-  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/pages.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/base.css">
+  <link rel="stylesheet" href="/css/components.css">
+  <link rel="stylesheet" href="/css/layout.css">
+  <link rel="stylesheet" href="/css/pages.css">
 </head>
 <body>
 <main class="container">

--- a/municipal.html
+++ b/municipal.html
@@ -13,10 +13,10 @@
   <meta name="twitter:title" content="Municipal Partner Portal (Beta)">
   <meta name="twitter:description" content="Resident-friendly documentation path, consistent submissions, faster approvals.">
   <meta name="twitter:image" content="/assets/og-hero.jpg">
-  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/pages.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/base.css">
+  <link rel="stylesheet" href="/css/components.css">
+  <link rel="stylesheet" href="/css/layout.css">
+  <link rel="stylesheet" href="/css/pages.css">
 </head>
 <body>
 <header>

--- a/remodel.html
+++ b/remodel.html
@@ -13,10 +13,10 @@
   <meta name="twitter:title" content="Residential Remodel Compliance — Photo/Video/Report">
   <meta name="twitter:description" content="Standardized documentation packages aligned to local submittals.">
   <meta name="twitter:image" content="/assets/og-hero.jpg">
-  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/pages.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/base.css">
+  <link rel="stylesheet" href="/css/components.css">
+  <link rel="stylesheet" href="/css/layout.css">
+  <link rel="stylesheet" href="/css/pages.css">
 </head>
 <body>
 <header>

--- a/services.html
+++ b/services.html
@@ -13,10 +13,10 @@
   <meta name="twitter:title" content="Services — Aerial Photo/Video, Mapping, Events">
   <meta name="twitter:description" content="Transparent deliverables, fast turnaround, and insured operators.">
   <meta name="twitter:image" content="/assets/og-hero.jpg">
-  <link rel="stylesheet" href="/css/base.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/components.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/layout.css?cb=1756180468">
-  <link rel="stylesheet" href="/css/pages.css?cb=1756180468">
+  <link rel="stylesheet" href="/css/base.css">
+  <link rel="stylesheet" href="/css/components.css">
+  <link rel="stylesheet" href="/css/layout.css">
+  <link rel="stylesheet" href="/css/pages.css">
 </head>
 <body>
   <header>


### PR DESCRIPTION
## Summary
- remove inline critical CSS from `index.html`
- load styles only from `/css/base.css`, `/css/components.css`, `/css/layout.css`, `/css/pages.css`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a2a21868832d9d5fce8fdb553b13