### PR TITLE
feat: add UI primitives

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,15 @@
+import { ComponentProps } from 'react';
+import { Link } from 'react-router-dom';
+
+type ButtonProps = ComponentProps<'button'> & { as?: 'button' | 'a' | 'link'; to?: string; href?: string };
+
+export default function Button({ as = 'button', to, href, className = '', ...rest }: ButtonProps) {
+  const base =
+    'inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium shadow-sm transition hover:opacity-90';
+  const primary = 'bg-brand-600 text-white';
+  const classes = `${base} ${primary} ${className}`;
+
+  if (as === 'a' && href) return <a className={classes} href={href} {...rest} />;
+  if (as === 'link' && to) return <Link className={classes} to={to} {...(rest as any)} />;
+  return <button className={classes} {...rest} />;
+}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+
+export default function Card({
+  title,
+  children,
+  footer
+}: {
+  title?: string;
+  children: ReactNode;
+  footer?: ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+      {title && <h3 className="text-lg font-semibold mb-2">{title}</h3>}
+      <div className="prose max-w-none">{children}</div>
+      {footer && <div className="mt-4">{footer}</div>}
+    </div>
+  );
+}

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -1,0 +1,5 @@
+import { PropsWithChildren } from 'react';
+
+export default function Container({ children }: PropsWithChildren) {
+  return <div className="mx-auto w-full max-w-[var(--container)] px-4 sm:px-6 lg:px-8">{children}</div>;
+}

--- a/src/components/CtaPanel.tsx
+++ b/src/components/CtaPanel.tsx
@@ -1,0 +1,25 @@
+import Button from './Button';
+
+export default function CtaPanel({
+  heading,
+  lead,
+  ctaText,
+  ctaTo
+}: {
+  heading: string;
+  lead?: string;
+  ctaText: string;
+  ctaTo: string;
+}) {
+  return (
+    <div className="rounded-xl bg-brand-600 text-white p-6 sm:p-8 shadow">
+      <h3 className="text-2xl font-semibold">{heading}</h3>
+      {lead && <p className="mt-2 opacity-90">{lead}</p>}
+      <div className="mt-4">
+        <Button as="link" to={ctaTo} className="bg-white text-brand-700 hover:opacity-100">
+          {ctaText}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,14 @@
+import Container from './Container';
+
+export default function Footer() {
+  return (
+    <footer className="border-t border-slate-200 bg-white">
+      <Container>
+        <div className="py-6 text-sm text-slate-600 flex flex-col sm:flex-row items-center justify-between">
+          <p>© {new Date().getFullYear()} Drone Depot</p>
+          <p className="mt-2 sm:mt-0">Gated RFP Desk · Concierge Matching · Resource Hub</p>
+        </div>
+      </Container>
+    </footer>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,36 @@
+import { NavLink } from 'react-router-dom';
+import Container from './Container';
+
+const nav = [
+  { to: '/', label: 'Home' },
+  { to: '/how-it-works', label: 'How It Works' },
+  { to: '/pilots', label: 'Pilots' },
+  { to: '/concierge', label: 'Concierge' },
+  { to: '/resources', label: 'Resources' },
+  { to: '/request', label: 'Request Service' }
+];
+
+export default function Header() {
+  return (
+    <header className="border-b border-slate-200 bg-white">
+      <Container>
+        <div className="flex items-center justify-between py-4">
+          <NavLink to="/" className="text-xl font-bold text-brand-700">Drone Depot</NavLink>
+          <nav className="hidden md:flex gap-6">
+            {nav.map((n) => (
+              <NavLink
+                key={n.to}
+                to={n.to}
+                className={({ isActive }) =>
+                  `text-sm hover:text-brand-700 ${isActive ? 'text-brand-700 font-medium' : 'text-slate-700'}`
+                }
+              >
+                {n.label}
+              </NavLink>
+            ))}
+          </nav>
+        </div>
+      </Container>
+    </header>
+  );
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,36 @@
+import Container from './Container';
+import Button from './Button';
+
+export default function Hero({
+  eyebrow = 'Drone Depot',
+  title,
+  subtitle,
+  primaryCta,
+  secondaryCta
+}: {
+  eyebrow?: string;
+  title: string;
+  subtitle?: string;
+  primaryCta?: { text: string; to: string };
+  secondaryCta?: { text: string; to: string };
+}) {
+  return (
+    <div className="bg-gradient-to-b from-slate-50 to-white">
+      <Container>
+        <div className="py-14 sm:py-20">
+          <p className="text-sm uppercase tracking-wide text-brand-700">{eyebrow}</p>
+          <h1 className="mt-2 text-4xl sm:text-5xl font-bold">{title}</h1>
+          {subtitle && <p className="mt-4 text-lg text-slate-600">{subtitle}</p>}
+          <div className="mt-6 flex gap-3">
+            {primaryCta && <Button as="link" to={primaryCta.to}>{primaryCta.text}</Button>}
+            {secondaryCta && (
+              <Button as="link" to={secondaryCta.to} className="bg-slate-900 text-white">
+                {secondaryCta.text}
+              </Button>
+            )}
+          </div>
+        </div>
+      </Container>
+    </div>
+  );
+}

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -1,0 +1,22 @@
+import Container from './Container';
+import { ReactNode } from 'react';
+
+export default function Section({
+  title,
+  subtitle,
+  children
+}: {
+  title?: string;
+  subtitle?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="py-12 sm:py-16">
+      <Container>
+        {title && <h2 className="text-2xl sm:text-3xl font-semibold mb-2">{title}</h2>}
+        {subtitle && <p className="text-slate-600 mb-6">{subtitle}</p>}
+        {children}
+      </Container>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add Container and Section layout components
- implement Button, Card, CtaPanel, and Hero building blocks
- add Header and Footer site chrome

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c074c2113c832d8795c5be523f1522